### PR TITLE
Adding in the Share button for Events.

### DIFF
--- a/hendrix_today_app/lib/Widgets/EventList.dart
+++ b/hendrix_today_app/lib/Widgets/EventList.dart
@@ -2,6 +2,7 @@
 
 import 'package:flutter/material.dart';
 import 'package:provider/provider.dart';
+import 'package:share_plus/share_plus.dart';
 
 import '../Objects/AppState.dart';
 import '../Objects/Event.dart';
@@ -32,6 +33,19 @@ class EventListState extends State<EventList> {
                     insetPadding:
                         EdgeInsets.symmetric(vertical: 200, horizontal: 50),
                     content: Column(children: [Text(item.desc.toString())]),
+                    actions: <Widget>[
+                      IconButton(
+                          color: Colors.black,
+                          onPressed: () {
+                            Navigator.pop(context);
+                            Share.share('"${item.title}" -${item.desc}',
+                                subject: 'Check out this quote!');
+                          },
+                          icon: Icon(
+                            Icons.ios_share,
+                            size: 20.0,
+                          )),
+                    ],
                   );
                   showDialog(
                     context: context,

--- a/hendrix_today_app/pubspec.yaml
+++ b/hendrix_today_app/pubspec.yaml
@@ -47,6 +47,7 @@ dependencies:
   gsheets: ^0.4.2
   sqflite: ^2.2.4+1
   csv: ^5.0.1
+  share_plus: ^6.3.1
   #excel: ^1.1.5
 
 dev_dependencies:


### PR DESCRIPTION
This will address issue #10 and add in a share icon at the bottom of the event AlertDialog. When pressed, the icon will open the native share API for the phone, bringing in the title and description of the event.