### PR TITLE
26 Add close button to event dialogs

### DIFF
--- a/hendrix_today_app/lib/Widgets/event_dialog.dart
+++ b/hendrix_today_app/lib/Widgets/event_dialog.dart
@@ -28,6 +28,11 @@ class EventDialog extends StatelessWidget {
           },
           icon: const Icon(Icons.share_outlined)
         ),
+        IconButton(
+          color: Colors.black,
+          onPressed: () => Navigator.pop(context),
+          icon: const Icon(Icons.close_outlined),
+        )
       ],
     );
   }


### PR DESCRIPTION
Added a close button to the right of the share button on event dialog boxes.

Closes #26