### PR TITLE
32 Display scheduled date/time for event in pop-up dialog

### DIFF
--- a/hendrix_today_app/lib/Objects/Event.dart
+++ b/hendrix_today_app/lib/Objects/Event.dart
@@ -4,7 +4,7 @@ class Event {
   final String? title;
   final String? desc;
   final String? time;
-  final DateTime? date; // change this to date
+  final DateTime? date;
   List<String>? tags;
 
   Event({
@@ -16,11 +16,18 @@ class Event {
   });
 
   /// Formats this [Event]'s date in a human-readable form.
+  /// Null dates return `'None available'`.
   /// 
   /// Example: `2023-06-14` becomes `Wed, Jun 14, 2023`
-  String dateToString() {
+  String displayDate() {
     final DateFormat formatter = DateFormat('EEE, MMM d, yyyy');
-    final String tmpdate = formatter.format(date ?? DateTime.now());
-    return tmpdate;
+    if (date != null) {
+      return formatter.format(date!);
+    } else {
+      return 'None available';
+    }
   }
+
+  /// Returns this [Event]'s time, or `'None available'` if it is null.
+  String displayTime() => time ?? 'None available';
 }

--- a/hendrix_today_app/lib/Objects/Event.dart
+++ b/hendrix_today_app/lib/Objects/Event.dart
@@ -15,8 +15,11 @@ class Event {
     this.tags,
   });
 
+  /// Formats this [Event]'s date in a human-readable form.
+  /// 
+  /// Example: `2023-06-14` becomes `Wed, Jun 14, 2023`
   String dateToString() {
-    final DateFormat formatter = DateFormat('MM/dd/yyyy');
+    final DateFormat formatter = DateFormat('EEE, MMM d, yyyy');
     final String tmpdate = formatter.format(date ?? DateTime.now());
     return tmpdate;
   }

--- a/hendrix_today_app/lib/Widgets/event_card.dart
+++ b/hendrix_today_app/lib/Widgets/event_card.dart
@@ -27,7 +27,7 @@ class EventCard extends StatelessWidget {
     return Card(
       child: ListTile(
         title: Text(event.title.toString()),
-        subtitle: Text(event.dateToString()),
+        subtitle: Text(event.displayDate()),
         onTap: () {
           showDialog(
             context: context,

--- a/hendrix_today_app/lib/Widgets/event_dialog.dart
+++ b/hendrix_today_app/lib/Widgets/event_dialog.dart
@@ -17,7 +17,14 @@ class EventDialog extends StatelessWidget {
         vertical: 100,
         horizontal: 50
       ),
-      content: Column(children: [Text(event.desc.toString())]),
+      content: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Text(event.dateToString()),
+          const SizedBox(height: 20),
+          Text(event.desc.toString()),
+        ],
+      ),
       actions: <Widget>[
         IconButton(
           color: Colors.black,

--- a/hendrix_today_app/lib/Widgets/event_dialog.dart
+++ b/hendrix_today_app/lib/Widgets/event_dialog.dart
@@ -20,7 +20,8 @@ class EventDialog extends StatelessWidget {
       content: Column(
         crossAxisAlignment: CrossAxisAlignment.start,
         children: [
-          Text(event.dateToString()),
+          Text('Date: ${event.displayDate()}'),
+          Text('Time: ${event.displayTime()}'),
           const SizedBox(height: 20),
           Text(event.desc.toString()),
         ],


### PR DESCRIPTION
In an event dialog box, the event's date and time are displayed above the description. The date is formatted as "Wed, Jun 14, 2023" and the time is formatted however it was in Hendrix Today's Excel sheet (it is stored as a string).

Closes 32