### PR TITLE
19 Can't scroll to last event

### DIFF
--- a/hendrix_today_app/lib/Widgets/event_list.dart
+++ b/hendrix_today_app/lib/Widgets/event_list.dart
@@ -14,13 +14,13 @@ class EventList extends StatelessWidget {
   Widget build(BuildContext context) {
     return Consumer<AppState>(
       builder: (context, appState, child) {
-        return ListView.builder(
+        return ListView(
           shrinkWrap: true,
           physics: const ScrollPhysics(),
-          itemCount: events.length,
-          itemBuilder: (context, index) => EventCard(
-            event: events[index]
-          ),
+          children: [
+            for (Event e in events) EventCard(event: e),
+            const SizedBox(height: 85),
+          ],
         );
       },
     );


### PR DESCRIPTION
Added an invisible buffer at the end of `EventList`s so that they can scroll past the floating navigation buttons

Closes #19