### PR TITLE
Fixing the calendar issues

### DIFF
--- a/hendrix_today_app/lib/widgets/event_calendar.dart
+++ b/hendrix_today_app/lib/widgets/event_calendar.dart
@@ -18,7 +18,6 @@ class EventCalendar extends StatefulWidget {
 //code obtained from TableCalendar repo: https://github.com/aleksanderwozniak/table_calendar
 class _EventCalendarState extends State<EventCalendar> {
   late final ValueNotifier<List<Event>> _selectedEvents;
-  CalendarFormat _calendarFormat = CalendarFormat.month;
   DateTime _focusedDay = DateTime.now();
   DateTime calendarRoot = DateTime.now();
   DateTime _selectedDay = DateTime.now();
@@ -36,9 +35,10 @@ class _EventCalendarState extends State<EventCalendar> {
   }
 
   List<Event> _getEventsForDay(DateTime day) {
-    return Provider.of<AppState>(context, listen: false).events
-      .where((event) => event.matchesDate(day))
-      .toList();
+    return Provider.of<AppState>(context, listen: false)
+        .events
+        .where((event) => event.matchesDate(day))
+        .toList();
   }
 
   void _onDaySelected(DateTime selectedDay, DateTime focusedDay) {
@@ -55,8 +55,8 @@ class _EventCalendarState extends State<EventCalendar> {
   @override
   Widget build(BuildContext context) {
     final today = DateTime.now();
-    final calendarStartDate = DateTime(today.year - 1, today.month, today.day);
-    final calendarEndDate = DateTime(today.year + 1, today.month, today.day);
+    final calendarStartDate = DateTime(today.year - 2, today.month, today.day);
+    final calendarEndDate = DateTime(today.year, today.month + 1, today.day);
     return SizedBox(
       child: Consumer<AppState>(
         builder: (context, appState, _) {
@@ -66,7 +66,10 @@ class _EventCalendarState extends State<EventCalendar> {
                 firstDay: calendarStartDate,
                 lastDay: calendarEndDate,
                 focusedDay: _focusedDay,
-                calendarFormat: _calendarFormat,
+                calendarFormat: CalendarFormat.month,
+                availableCalendarFormats: const {
+                  CalendarFormat.month: 'Month',
+                },
                 eventLoader: _getEventsForDay,
                 selectedDayPredicate: (day) {
                   // Use `selectedDayPredicate` to determine which day is currently selected.
@@ -76,17 +79,13 @@ class _EventCalendarState extends State<EventCalendar> {
                   return isSameDay(_selectedDay, day);
                 },
                 onDaySelected: _onDaySelected,
-                onFormatChanged: (format) {
-                  if (_calendarFormat != format) {
-                    // Call `setState()` when updating calendar format
-                    setState(() {
-                      _calendarFormat = format;
-                    });
-                  }
-                },
                 onPageChanged: (focusedDay) {
                   // No need to call `setState()` here
+                  _selectedDay = DateTime(
+                      focusedDay.year, focusedDay.month, _selectedDay.day);
                   _focusedDay = focusedDay;
+                  _selectedEvents.value = _getEventsForDay(_selectedDay);
+                  setState(() {});
                 },
               ),
               //EventList()

--- a/hendrix_today_app/lib/widgets/event_calendar.dart
+++ b/hendrix_today_app/lib/widgets/event_calendar.dart
@@ -87,6 +87,9 @@ class _EventCalendarState extends State<EventCalendar> {
                   _selectedEvents.value = _getEventsForDay(_selectedDay);
                   setState(() {});
                 },
+                onCalendarCreated: (pageController) {
+                  _selectedEvents.value = _getEventsForDay(_selectedDay);
+                },
               ),
               //EventList()
               Expanded(

--- a/hendrix_today_app/lib/widgets/screen_container.dart
+++ b/hendrix_today_app/lib/widgets/screen_container.dart
@@ -79,24 +79,26 @@ class _ScreenContainerState extends State<ScreenContainer> {
         //       icon: const Icon(Icons.account_circle)),
         actions: [
           selectedIndex < 2
-              ? DropdownButton<String>(
-                  value: dropdownValue,
-                  style: const TextStyle(color: Colors.white),
-                  dropdownColor: webOrange,
-                  items: dropdownItems.map((itemone) {
-                    return DropdownMenuItem(
-                        value: itemone,
-                        child: Text(itemone,
-                            style: const TextStyle(
-                              fontFamily: 'Museo',
-                              fontSize: 15,
-                            )));
-                  }).toList(),
-                  onChanged: (newValue) {
-                    setState(() {
-                      dropdownValue = newValue.toString();
-                    });
-                  },
+              ? DropdownButtonHideUnderline(
+                  child: DropdownButton<String>(
+                    value: dropdownValue,
+                    style: const TextStyle(color: Colors.white),
+                    dropdownColor: webOrange,
+                    items: dropdownItems.map((itemone) {
+                      return DropdownMenuItem(
+                          value: itemone,
+                          child: Text(itemone,
+                              style: const TextStyle(
+                                fontFamily: 'Museo',
+                                fontSize: 15,
+                              )));
+                    }).toList(),
+                    onChanged: (newValue) {
+                      setState(() {
+                        dropdownValue = newValue.toString();
+                      });
+                    },
+                  ),
                 )
               : Container(),
         ],

--- a/hendrix_today_app/pubspec.yaml
+++ b/hendrix_today_app/pubspec.yaml
@@ -37,7 +37,7 @@ dependencies:
   # The following adds the Cupertino Icons font to your application.
   # Use with the CupertinoIcons class for iOS style icons.
   cupertino_icons: ^1.0.2
-  table_calendar: ^3.0.8
+  table_calendar: ^3.0.9
   anim_search_bar: ^2.0.2
   firebase_core: ^2.3.0
   firebase_auth: ^4.1.3


### PR DESCRIPTION
There is only the Month option for the calendar now, closes #30. Took a while to see that the selection option would disappear by only giving it one option.

I made the scroll-back date go back two years instead of one, partially addressing #3, but not completely. There is no way to make it infinite scrolling. So we might have to search by earliest date, and just record that in appState when the events are updated from Firebase?

Also partially addresses #52. Now calendar events will show up for the current day when loaded.