### PR TITLE
Added more Event details, home page is time-sensitive, fixed app bar event filter

### DIFF
--- a/hendrix_today_app/lib/objects/app_state.dart
+++ b/hendrix_today_app/lib/objects/app_state.dart
@@ -15,7 +15,6 @@ import 'package:firebase_ui_auth/firebase_ui_auth.dart';
 class AppState extends ChangeNotifier {
   List<Event> _events = [];
   List<Event> get events => _events;
-  num answer = 42;
 
   AppState() {
     init();
@@ -43,12 +42,13 @@ class AppState extends ChangeNotifier {
           debugPrint("in snapshot");
           _events = [];
           for (var document in snapshot.docs) {
-            _events.add(Event(
-              title: document.data()['title'],
-              desc: document.data()['desc'],
-              time: document.data()['time'],
-              date: DateUtils.dateOnly(document.data()['date'].toDate()),
-            ));
+            final Map<String, dynamic> data = document.data();
+            final Event? event = Event.fromFirebase(data);
+            if (event != null) {
+              _events.add(event);
+            } else {
+              debugPrint("Throwing away invalid event data: $data");
+            }
           }
           //  print(snapshot.docChanges.toString()); //prints changes
           firstSnapshot = false;

--- a/hendrix_today_app/lib/objects/app_state.dart
+++ b/hendrix_today_app/lib/objects/app_state.dart
@@ -15,6 +15,16 @@ import 'package:firebase_ui_auth/firebase_ui_auth.dart';
 class AppState extends ChangeNotifier {
   List<Event> _events = [];
   List<Event> get events => _events;
+  EventType _eventTypeFilter = EventType.announcement;
+  EventType get eventTypeFilter => _eventTypeFilter;
+  
+  void updateEventTypeFilter(String? s) {
+    final maybeEventType = EventType.fromString(s);
+    if (maybeEventType != null) {
+      _eventTypeFilter = maybeEventType;
+      notifyListeners();
+    }
+  }
 
   AppState() {
     init();

--- a/hendrix_today_app/lib/objects/event.dart
+++ b/hendrix_today_app/lib/objects/event.dart
@@ -32,6 +32,7 @@ class Event {
   final DateTime beginPosting;
   final DateTime endPosting;
   final DateTime? applyDeadline;
+  final List<String> tags;
 
   /// Default [Event] constructor. When constructing events from Firebase data, 
   /// please consider using `Event.fromFirebase(Map<String, dynamic> data)`.
@@ -47,6 +48,7 @@ class Event {
     required this.beginPosting,
     required this.endPosting,
     required this.applyDeadline,
+    required this.tags,
   });
 
   /// Converts Firebase data into an [Event]. The return value will be null if 
@@ -85,6 +87,10 @@ class Event {
     final DateTime? applyDeadline =
       cast<Timestamp>(data["applyDeadline"])?.toDate();
 
+    final List<String> tags =
+      (cast<String>(data["tags"]) ?? "")
+      .split(';');
+
     return Event(
       title: title,
       desc: desc,
@@ -97,6 +103,7 @@ class Event {
       beginPosting: beginPosting,
       endPosting: endPosting,
       applyDeadline: applyDeadline,
+      tags: tags,
     );
   }
 

--- a/hendrix_today_app/lib/objects/event.dart
+++ b/hendrix_today_app/lib/objects/event.dart
@@ -7,16 +7,29 @@ import 'package:intl/intl.dart'
     show DateFormat;
 
 enum EventType {
-  event, meeting, announcement, lostAndFound;
+  announcement, event, meeting, lostAndFound;
 
-  static EventType? fromString(String? s) {
-    const map = <String, EventType>{
-      "event": event, "events": event,
-      "meeting": meeting, "meetings": meeting,
-      "announcement": announcement, "announcements": announcement,
-      "lost & found": lostAndFound, "lost and found": lostAndFound,
-    };
-    return map[s?.trim().toLowerCase()];
+  @override
+  String toString() {
+    switch (this) {
+      case announcement: return "Announcements";
+      case event: return "Events";
+      case meeting: return "Meetings";
+      case lostAndFound: return "Lost & Found";
+    }
+  }
+
+  static EventType? fromString(String? str) {    
+    switch (str?.trim().toLowerCase()) {
+      case "announcement":
+      case "announcements": return announcement;
+      case "event":
+      case "events": return event;
+      case "meeting":
+      case "meetings": return meeting;
+      case "lost & found": return lostAndFound;
+      default: return null;
+    }
   }
 }
 

--- a/hendrix_today_app/lib/objects/event.dart
+++ b/hendrix_today_app/lib/objects/event.dart
@@ -1,46 +1,125 @@
 import 'package:flutter/material.dart'
     show DateUtils;
 
-import 'package:intl/intl.dart';
+import 'package:cloud_firestore/cloud_firestore.dart'
+    show Timestamp;
+import 'package:intl/intl.dart'
+    show DateFormat;
+
+enum EventType {
+  event, meeting, announcement, lostAndFound;
+
+  static EventType? fromString(String? s) {
+    const map = <String, EventType>{
+      "event": event, "events": event,
+      "meeting": meeting, "meetings": meeting,
+      "announcement": announcement, "announcements": announcement,
+      "lost & found": lostAndFound, "lost and found": lostAndFound,
+    };
+    return map[s?.trim().toLowerCase()];
+  }
+}
 
 class Event {
-  final String? title;
-  final String? desc;
-  final String? time;
-  final DateTime? date;
-  List<String>? tags;
+  final String title;
+  final String desc;
+  final EventType eventType;
+  final DateTime date;
+  final String time;
+  final String location;
+  final String contactName;
+  final String contactEmail;
+  final DateTime beginPosting;
+  final DateTime endPosting;
+  final DateTime? applyDeadline;
 
+  /// Default [Event] constructor. When constructing events from Firebase data, 
+  /// please consider using `Event.fromFirebase(Map<String, dynamic> data)`.
   Event({
-    this.title,
-    this.desc,
-    this.time,
-    this.date,
-    this.tags,
+    required this.title,
+    required this.desc,
+    required this.eventType,
+    required this.date,
+    required this.time,
+    required this.location,
+    required this.contactName,
+    required this.contactEmail,
+    required this.beginPosting,
+    required this.endPosting,
+    required this.applyDeadline,
   });
+
+  /// Converts Firebase data into an [Event]. The return value will be null if 
+  /// the given data is invalid (i.e., has an invalid type or date).
+  static Event? fromFirebase(Map<String, dynamic> data) {
+    // Convenient caster: https://stackoverflow.com/a/67435226
+    T? cast<T>(dynamic x) => (x is T) ? x : null;
+
+    final String title = cast(data["title"]) ?? "Untitled Event";
+    final String desc = cast(data["desc"]) ?? "No description given.";
+
+    final EventType? maybeEventType = EventType.fromString(data["type"]);
+    if (maybeEventType == null) { return null; }
+    final EventType eventType = maybeEventType;
+    
+    final Timestamp? maybeDate = cast(data["date"]);
+    if (maybeDate == null) { return null; }
+    final DateTime date = maybeDate.toDate();
+
+    final String time = cast(data["time"]) ?? "No time given";
+    final String location = cast(data["location"]) ?? "No location given";
+
+    final String contactName =
+      cast(data["contactName"]) ?? "No contact name given";
+    final String contactEmail =
+      cast(data["contactEmail"]) ?? "No contact email given";
+    
+    final Timestamp? maybeBeginPosting = cast(data["beginPosting"]);
+    if (maybeBeginPosting == null) { return null; }
+    final DateTime beginPosting = maybeBeginPosting.toDate();
+
+    final Timestamp? maybeEndPosting = cast(data["endPosting"]);
+    if (maybeEndPosting == null) { return null; }
+    final DateTime endPosting = maybeEndPosting.toDate();
+
+    final DateTime? applyDeadline =
+      cast<Timestamp>(data["applyDeadline"])?.toDate();
+
+    return Event(
+      title: title,
+      desc: desc,
+      eventType: eventType,
+      date: date,
+      time: time,
+      location: location,
+      contactName: contactName,
+      contactEmail: contactEmail,
+      beginPosting: beginPosting,
+      endPosting: endPosting,
+      applyDeadline: applyDeadline,
+    );
+  }
 
   /// Formats this [Event]'s date in a human-readable form.
   /// Null dates return `'None available'`.
   /// 
   /// Example: `2023-06-14` becomes `Wed, Jun 14, 2023`
-  String displayDate() {
-    final DateFormat formatter = DateFormat('EEE, MMM d, yyyy');
-    if (date != null) {
-      return formatter.format(date!);
-    } else {
-      return 'None available';
-    }
-  }
-
-  /// Returns this [Event]'s time, or `'None available'` if it is null.
-  String displayTime() => time ?? 'None available';
+  String displayDate() => DateFormat('EEE, MMM d, yyyy').format(date);
 
   /// Checks if `searchQuery` appears in this [Event]'s title or description 
   /// (case-insensitive).
   bool containsString(String searchQuery) =>
-    title!.toLowerCase().contains(searchQuery.toLowerCase()) |
-    desc!.toLowerCase().contains(searchQuery.toLowerCase());
+    title.toLowerCase().contains(searchQuery.toLowerCase()) |
+    desc.toLowerCase().contains(searchQuery.toLowerCase());
   
   /// Checks if this [Event]'s date is the same day as `match`. Note that the 
   /// time field of `Event.date` is set to midnight UTC.
   bool matchesDate(DateTime match) => DateUtils.isSameDay(date, match);
+
+  /// Checks if the given [DateTime] falls in this [Event]'s posting range.
+  /// Includes both range end points.
+  bool inPostingRange(DateTime day) =>
+    DateUtils.isSameDay(day, beginPosting) ||
+    DateUtils.isSameDay(day, endPosting) ||
+    (day.isAfter(beginPosting) && day.isBefore(endPosting));
 }

--- a/hendrix_today_app/lib/screens/home_screen.dart
+++ b/hendrix_today_app/lib/screens/home_screen.dart
@@ -2,6 +2,7 @@ import 'package:flutter/material.dart';
 
 import 'package:hendrix_today_app/widgets/event_list.dart';
 import 'package:hendrix_today_app/objects/app_state.dart';
+import 'package:hendrix_today_app/objects/event.dart';
 
 import 'package:provider/provider.dart';
 
@@ -15,14 +16,20 @@ class MyHomeScreen extends StatefulWidget {
 class _MyHomeScreenState extends State<MyHomeScreen> {
   @override
   Widget build(BuildContext context) {
-    final allEvents = Provider.of<AppState>(context).events;
+    final appState = Provider.of<AppState>(context);
+    final filteredEvents = appState.events
+      .where((Event e) =>
+        e.eventType == appState.eventTypeFilter &&
+        e.inPostingRange(DateTime.now()),)
+      .toList();
+    
     return SizedBox(
         width: MediaQuery.of(context).size.width,
         child: ListView(
           children: <Widget>[
             //Image.asset('assets/webOrange_banner.png',
             //    key: const Key("Banner")),
-            EventList(events: allEvents),
+            EventList(events: filteredEvents),
           ],
         ));
   }

--- a/hendrix_today_app/lib/widgets/event_calendar.dart
+++ b/hendrix_today_app/lib/widgets/event_calendar.dart
@@ -17,33 +17,22 @@ class EventCalendar extends StatefulWidget {
 //creation of the TableCalendar
 //code obtained from TableCalendar repo: https://github.com/aleksanderwozniak/table_calendar
 class _EventCalendarState extends State<EventCalendar> {
-  late final ValueNotifier<List<Event>> _selectedEvents;
   DateTime _focusedDay = DateTime.now();
   DateTime calendarRoot = DateTime.now();
   DateTime _selectedDay = DateTime.now();
 
-  @override
-  void initState() {
-    super.initState();
-    _selectedEvents = ValueNotifier(_getEventsForDay(_selectedDay));
-  }
-
-  @override
-  void dispose() {
-    _selectedEvents.dispose();
-    super.dispose();
-  }
+  List<Event> _applyEventFilters(AppState appState, DateTime day) =>
+    appState.events
+    .where((event) =>
+      event.matchesDate(day) &&
+      event.eventType == appState.eventTypeFilter)
+    .toList();
 
   /// Gets the events/announcements/etc. for the given day while also applying 
   /// relevant filters like the type filter dropdown on the app bar.
   List<Event> _getEventsForDay(DateTime day) {
     final appState = Provider.of<AppState>(context, listen: false);
-    return appState
-        .events
-        .where((event) =>
-          event.matchesDate(day) &&
-          event.eventType == appState.eventTypeFilter)
-        .toList();
+    return _applyEventFilters(appState, day);
   }
 
   void _onDaySelected(DateTime selectedDay, DateTime focusedDay) {
@@ -52,8 +41,6 @@ class _EventCalendarState extends State<EventCalendar> {
         _selectedDay = selectedDay;
         _focusedDay = focusedDay;
       });
-
-      _selectedEvents.value = _getEventsForDay(selectedDay);
     }
   }
 
@@ -89,18 +76,15 @@ class _EventCalendarState extends State<EventCalendar> {
                   _selectedDay = DateTime(
                       focusedDay.year, focusedDay.month, _selectedDay.day);
                   _focusedDay = focusedDay;
-                  _selectedEvents.value = _getEventsForDay(_selectedDay);
                   setState(() {});
-                },
-                onCalendarCreated: (pageController) {
-                  _selectedEvents.value = _getEventsForDay(_selectedDay);
                 },
               ),
               //EventList()
               Expanded(
-                child: ValueListenableBuilder<List<Event>>(
-                  valueListenable: _selectedEvents,
-                  builder: (context, events, _) => EventList(events: events),
+                child: Consumer<AppState>(
+                  builder: (context, appState, _) => EventList(
+                    events: _applyEventFilters(appState, _selectedDay),
+                  ),
                 ),
               ),
             ],

--- a/hendrix_today_app/lib/widgets/event_calendar.dart
+++ b/hendrix_today_app/lib/widgets/event_calendar.dart
@@ -34,10 +34,15 @@ class _EventCalendarState extends State<EventCalendar> {
     super.dispose();
   }
 
+  /// Gets the events/announcements/etc. for the given day while also applying 
+  /// relevant filters like the type filter dropdown on the app bar.
   List<Event> _getEventsForDay(DateTime day) {
-    return Provider.of<AppState>(context, listen: false)
+    final appState = Provider.of<AppState>(context, listen: false);
+    return appState
         .events
-        .where((event) => event.matchesDate(day))
+        .where((event) =>
+          event.matchesDate(day) &&
+          event.eventType == appState.eventTypeFilter)
         .toList();
   }
 

--- a/hendrix_today_app/lib/widgets/event_dialog.dart
+++ b/hendrix_today_app/lib/widgets/event_dialog.dart
@@ -13,7 +13,7 @@ class EventDialog extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     return AlertDialog(
-      titlePadding: EdgeInsets.fromLTRB(0, 24, 18, 0),
+      titlePadding: const EdgeInsets.fromLTRB(0, 24, 18, 0),
       shape: const RoundedRectangleBorder(
           borderRadius: BorderRadius.all(Radius.circular(0.0))),
       title: Stack(children: [
@@ -41,7 +41,7 @@ class EventDialog extends StatelessWidget {
               ),
             ),
             Text(
-              event.displayTime(),
+              event.time,
               style: const TextStyle(
                 fontStyle: FontStyle.italic,
                 fontSize: 14,
@@ -56,7 +56,7 @@ class EventDialog extends StatelessWidget {
           child: Column(
             children: [
               IconButton(
-                  padding: EdgeInsets.all(0),
+                  padding: const EdgeInsets.all(0),
                   color: const Color.fromARGB(255, 202, 81, 39),
                   icon: const Icon(
                     Icons.close,

--- a/hendrix_today_app/lib/widgets/screen_container.dart
+++ b/hendrix_today_app/lib/widgets/screen_container.dart
@@ -1,11 +1,14 @@
 import 'package:flutter/material.dart';
-import 'package:hendrix_today_app/screens/calendar_screen.dart';
 
+import 'package:hendrix_today_app/objects/app_state.dart';
+import 'package:hendrix_today_app/objects/event.dart';
+import 'package:hendrix_today_app/screens/calendar_screen.dart';
 import 'package:hendrix_today_app/screens/resource_screen.dart';
 import 'package:hendrix_today_app/screens/search_screen.dart';
 import 'package:hendrix_today_app/screens/home_screen.dart';
 
 import 'package:url_launcher/url_launcher.dart';
+import 'package:provider/provider.dart';
 
 class ScreenContainer extends StatefulWidget {
   const ScreenContainer({super.key});
@@ -20,12 +23,6 @@ class _ScreenContainerState extends State<ScreenContainer> {
   List<Widget> pages = []; //contains each page
   List<String> titles = [];
   List<String> menuLinks = []; //contains the title of each page
-  final List<String> dropdownItems = [
-    "events",
-    "announcements",
-    "meetings",
-  ];
-  String dropdownValue = "events";
 
   @override
   void initState() {
@@ -53,6 +50,11 @@ class _ScreenContainerState extends State<ScreenContainer> {
     ];
   }
 
+  List<String> _getDropdownNames() =>
+    EventType.values
+    .map((et) => et.toString())
+    .toList();
+
   _launchURLApp() async {
     int dayOfWeek = DateTime.now().weekday;
     String menuLink = menuLinks[dayOfWeek - 1];
@@ -66,6 +68,7 @@ class _ScreenContainerState extends State<ScreenContainer> {
 
   @override
   Widget build(BuildContext context) {
+    final appState = Provider.of<AppState>(context);
     return Scaffold(
       appBar: AppBar(
         backgroundColor: webOrange,
@@ -81,10 +84,10 @@ class _ScreenContainerState extends State<ScreenContainer> {
           selectedIndex < 2
               ? DropdownButtonHideUnderline(
                   child: DropdownButton<String>(
-                    value: dropdownValue,
+                    value: appState.eventTypeFilter.toString(),
                     style: const TextStyle(color: Colors.white),
                     dropdownColor: webOrange,
-                    items: dropdownItems.map((itemone) {
+                    items: _getDropdownNames().map((itemone) {
                       return DropdownMenuItem(
                           value: itemone,
                           child: Text(itemone,
@@ -95,7 +98,7 @@ class _ScreenContainerState extends State<ScreenContainer> {
                     }).toList(),
                     onChanged: (newValue) {
                       setState(() {
-                        dropdownValue = newValue.toString();
+                        appState.updateEventTypeFilter(newValue);
                       });
                     },
                   ),

--- a/hendrix_today_app/pubspec.lock
+++ b/hendrix_today_app/pubspec.lock
@@ -790,10 +790,10 @@ packages:
     dependency: transitive
     description:
       name: url_launcher_platform_interface
-      sha256: "6c9ca697a5ae218ce56cece69d46128169a58aa8653c1b01d26fcd4aad8c4370"
+      sha256: bfdfa402f1f3298637d71ca8ecfe840b4696698213d5346e9d12d4ab647ee2ea
       url: "https://pub.dev"
     source: hosted
-    version: "2.1.2"
+    version: "2.1.3"
   url_launcher_web:
     dependency: transitive
     description:


### PR DESCRIPTION
`Event` objects now store much more information; items will only appear on the home page if the current date is within the item's posting date range; and the dropdown filter on the app bar now works on the pages above which it appears (the home and calendar pages).

I know we discussed during our 2023/06/21 meeting that the home page should probably only show announcements, so that may be a future issue. Also a known issue in this PR that will need to be logged after merging is that updating the dropdown filter on the app bar doesn't update the contents of the event list beneath the calendar. 

Closes #4, closes #37, closes #57