### PR TITLE
Caf menu and submission form open in external web browser

### DIFF
--- a/hendrix_today_app/lib/screens/resource_screen.dart
+++ b/hendrix_today_app/lib/screens/resource_screen.dart
@@ -17,7 +17,7 @@ _launchURL() async {
       'https://forms.office.com/Pages/ResponsePage.aspx?id=jMH2DNLQP0qD0GY9Ygpj020T9lhtzfhCi8WBPrgNg0xURFZXMEEyUzUwR0lNSzZTTDdWWEQwOERSWiQlQCN0PWcu';
   final uri = Uri.parse(submissionFormUrl);
   if (await canLaunchUrl(uri)) {
-    await launchUrl(uri);
+    await launchUrl(uri, mode: LaunchMode.externalApplication);
   } else {
     throw 'Could not launch $submissionFormUrl';
   }

--- a/hendrix_today_app/lib/widgets/screen_container.dart
+++ b/hendrix_today_app/lib/widgets/screen_container.dart
@@ -22,7 +22,6 @@ class _ScreenContainerState extends State<ScreenContainer> {
   int selectedIndex = 0;
   List<Widget> pages = []; //contains each page
   List<String> titles = [];
-  List<String> menuLinks = []; //contains the title of each page
 
   @override
   void initState() {
@@ -39,15 +38,6 @@ class _ScreenContainerState extends State<ScreenContainer> {
       "search",
       "resources",
     ];
-    menuLinks = [
-      "https://www.hendrix.edu/diningservices/default.aspx?id=1003",
-      "https://www.hendrix.edu/diningservices/default.aspx?id=1004",
-      "https://www.hendrix.edu/diningservices/default.aspx?id=1005",
-      "https://www.hendrix.edu/diningservices/default.aspx?id=1006",
-      "https://www.hendrix.edu/diningservices/default.aspx?id=1007",
-      "https://www.hendrix.edu/diningservices/default.aspx?id=1008",
-      "https://www.hendrix.edu/diningservices/default.aspx?id=1002"
-    ];
   }
 
   List<String> _getDropdownNames() =>
@@ -56,11 +46,20 @@ class _ScreenContainerState extends State<ScreenContainer> {
     .toList();
 
   _launchURLApp() async {
+    const menuLinks = [
+      "https://www.hendrix.edu/diningservices/default.aspx?id=1003", // Mo
+      "https://www.hendrix.edu/diningservices/default.aspx?id=1004", // Tu
+      "https://www.hendrix.edu/diningservices/default.aspx?id=1005", // We
+      "https://www.hendrix.edu/diningservices/default.aspx?id=1006", // Th
+      "https://www.hendrix.edu/diningservices/default.aspx?id=1007", // Fr
+      "https://www.hendrix.edu/diningservices/default.aspx?id=1008", // Sa
+      "https://www.hendrix.edu/diningservices/default.aspx?id=1002", // Su
+    ];
     int dayOfWeek = DateTime.now().weekday;
     String menuLink = menuLinks[dayOfWeek - 1];
     Uri menuUrl = Uri.parse(menuLink);
     if (await canLaunchUrl(menuUrl)) {
-      await launchUrl(menuUrl);
+      await launchUrl(menuUrl, mode: LaunchMode.externalApplication);
     } else {
       throw 'Could not launch $menuUrl';
     }


### PR DESCRIPTION
Technically not an embedded web browser - there is an option for that (`LaunchMode.inAppWebView`), but its behavior on Android is to open the website on top of the app with no way to leave but to swipe back or press the device's back button, which is the initial behavior that raised this issue. I assume its behavior on iOS is desirable, but I feel like modifying link behavior based on platform just to avoid writing a custom embedded-browser page for Android isn't the right thing to do.

Closes #28