### PR TITLE
Fixing the app name for Android

### DIFF
--- a/hendrix_today_app/android/app/src/main/AndroidManifest.xml
+++ b/hendrix_today_app/android/app/src/main/AndroidManifest.xml
@@ -1,7 +1,7 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
     package="com.example.hendrix_today_app">
    <application
-        android:label="hendrix_today_app"
+        android:label="Hendrix Today"
         android:name="${applicationName}"
         android:icon="@mipmap/ic_launcher"
         android:roundIcon="@mipmap/ic_launcher_round">


### PR DESCRIPTION
In the AndroidManifest.xml, to change the name of the app, you need to change "label" instead of "name".